### PR TITLE
Enable selecting and downloading scraped images

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Scrape publisher, author, license, and media credits from the current page, then
 - Extracts common metadata (publisher, author, site, canonical URL, dates, license)
 - Finds media on the page (images/videos/audio) with alt, caption, and nearby credit text
 - Suggests a recommended credit for each media item
+- Shows media thumbnails with checkboxes so you can pick specific items
+- Download selected media directly from the popup
 - Save to local storage and manage from the Options page
 - Export single capture or all captures as JSON
 - Background auto-capture on download (best effort)

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -17,6 +17,8 @@ section { padding: 10px 12px; }
 section#page div { margin: 2px 0; }
 section#media .item { border: 1px solid #ddd; border-radius: 6px; padding: 8px; margin: 8px 0; background: #fafafa; }
 section#media .item .src { word-break: break-all; color: #333; }
+section#media .item img.preview { max-width: 100%; display: block; margin: 4px 0; }
+section#media .item label.select { display: flex; align-items: center; gap: 4px; }
 label.small { color: #666; font-size: 11px; }
 footer { display: flex; gap: 8px; align-items: center; justify-content: space-between; padding: 10px 12px; border-top: 1px solid #ddd; }
 

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -18,6 +18,7 @@
         <button id="save">Save</button>
         <button id="copy">Copy JSON</button>
         <button id="download">Download JSON</button>
+        <button id="download-media">Download</button>
         <a id="manage" href="../options/options.html" target="_blank">Manage Saved</a>
       </footer>
     </div>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -60,7 +60,12 @@ function render(result) {
   media.forEach((m, idx) => {
     const container = e('div', { className: 'item' });
     container.appendChild(e('div', { className: 'small' }, [`#${idx + 1} ${m.type}`]));
-    if (m.src) container.appendChild(e('div', { className: 'src mono' }, [m.src]));
+    if (m.src) {
+      container.appendChild(e('img', { src: m.src, className: 'preview' }));
+      container.appendChild(e('div', { className: 'src mono' }, [m.src]));
+      const cb = e('input', { type: 'checkbox', className: 'media-select', value: m.src });
+      container.appendChild(e('label', { className: 'small select' }, [cb, ' Select']));
+    }
     if (m.alt) container.appendChild(e('div', {}, ['Alt: ', e('span', { className: 'mono' }, [m.alt])]));
     if (m.caption) container.appendChild(e('div', {}, ['Caption: ', e('span', { className: 'mono' }, [m.caption])]));
     if (m.credit) container.appendChild(e('div', {}, ['Credit: ', e('span', { className: 'mono' }, [m.credit])]));
@@ -96,6 +101,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const saveBtn = document.getElementById('save');
   const copyBtn = document.getElementById('copy');
   const downloadBtn = document.getElementById('download');
+  const downloadMediaBtn = document.getElementById('download-media');
 
   let current = null;
 
@@ -128,6 +134,15 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (!current) return;
     const fnSafe = (current.page?.title || 'metadata').replace(/[^a-z0-9]+/gi, '_').slice(0, 50);
     downloadJSON(current, `${fnSafe || 'metadata'}.json`);
+  });
+  downloadMediaBtn.addEventListener('click', () => {
+    const selected = Array.from(document.querySelectorAll('.media-select:checked'));
+    selected.forEach((cb) => {
+      const url = cb.value;
+      if (url) {
+        chrome.downloads.download({ url });
+      }
+    });
   });
 
   doScrape();


### PR DESCRIPTION
## Summary
- Render scraped media as thumbnails with checkboxes for selection
- Add Download button to save chosen media via chrome.downloads API
- Document image selection and download feature in README

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68b24d6d567c8330ab0ea7d41ee711ec